### PR TITLE
update BeforeTargets name for new Xamarin.VS projects

### DIFF
--- a/FirstFloor.Xcc/Targets/Xcc.targets
+++ b/FirstFloor.Xcc/Targets/Xcc.targets
@@ -12,7 +12,7 @@ Copyright (C) First Floor Software. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="PreprocessXaml" AssemblyFile="$(MSBuildThisFileDirectory)..\tools\Xcc.dll" />
 
-  <Target Name="GenerateXaml" BeforeTargets="MarkupCompilePass1" AfterTargets="_PreXamlG">
+  <Target Name="GenerateXaml" BeforeTargets="XamlMarkupCompilePass1" AfterTargets="_PreXamlG">
     <!-- create collection for embedded xaml resources -->
     <CreateItem Include="@(EmbeddedResource)" Condition="'%(Extension)' == '.xaml'">
       <Output TaskParameter="Include" ItemName="EmbeddedXamlResource"/>


### PR DESCRIPTION
Hey guys, this references #8 - tho I only came upon this issue after I fixed it (for me at least).

I'm not an msbuild expert, but I found that this awesome preprocessor had stopped working when I included it in a brand new Xamarin.Forms project I created with Visual Studio 2015 (Update 2). I was actually heartbroken, because it is one of THE most useful utilities I've ever come across for the ignorable xaml intellisense attributes.

I did a little digging, and it looks like sometime in the last 9 months or so, they (I presume Xamarin because it's their `xamarin.forms.targets` file which is different) changed the name of the one target task from `MarkupCompilePass1` to `XamlMarkupCompilePass1`.

I tweaked the `xcc.targets` file in my nuget packages folder to use this new name (as per this PR) and it worked!

Sadly I am not an msbuild expert, so I do not know if this will break previous versions, and I do not know how to make it do a check for multiple targets (e.g. something like `BeforeTargets="MarkupCompilePass1;XamlMarkupCompilePass1"` ? or what order they should be in, or even if it can be be done this way). I hope you can help out with this, because there's a few sad xamarin forms devs out there right now.

Obviously if this is NOT the way to fix it, then let me know, and I'll not trouble you with it again. 

I think the `xcc.debug.targets` file will probably need the same treatment.

Either way, thanks for building this thing! It is SUCH a time saver! :thumbsup:
